### PR TITLE
POC: admin authorization directly on router

### DIFF
--- a/backend/lib/kjer_si/rooms.ex
+++ b/backend/lib/kjer_si/rooms.ex
@@ -115,7 +115,9 @@ defmodule KjerSi.Rooms do
 
   """
   def list_rooms do
-    Repo.all(Room)
+    Room
+    |> Repo.all
+    |> Repo.preload(:users)
   end
 
   @doc """

--- a/backend/lib/kjer_si_web/controllers/admin/admin_room_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/admin/admin_room_controller.ex
@@ -1,0 +1,21 @@
+defmodule KjerSiWeb.Admin.AdminRoomController do
+  use KjerSiWeb, :controller
+
+  alias KjerSi.Rooms
+  alias KjerSi.Rooms.Room
+
+  action_fallback KjerSiWeb.FallbackController
+
+  def index(conn, _params) do
+    rooms = Rooms.list_rooms()
+    render(conn, "index.json", rooms: rooms)
+  end
+
+  def delete(conn, %{"id" => id}) do
+    room = Rooms.get_room!(id)
+
+    with {:ok, %Room{}} <- Rooms.delete_room(room) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/backend/lib/kjer_si_web/controllers/admin/admin_user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/admin/admin_user_controller.ex
@@ -1,0 +1,21 @@
+defmodule KjerSiWeb.Admin.AdminUserController do
+  use KjerSiWeb, :controller
+
+  alias KjerSi.Accounts
+  alias KjerSi.Accounts.User
+
+  action_fallback KjerSiWeb.FallbackController
+
+  def index(conn, _params) do
+    users = Accounts.list_users()
+    render(conn, "index.json", users: users)
+  end
+
+  def update(conn, %{"id" => id, "user" => user_params}) do
+    user = Accounts.get_user!(id)
+
+    with {:ok, %User{} = user} <- Accounts.update_user(user, user_params) do
+      render(conn, "show.json", user: user)
+    end
+  end
+end

--- a/backend/lib/kjer_si_web/controllers/room_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/room_controller.ex
@@ -6,8 +6,6 @@ defmodule KjerSiWeb.RoomController do
 
   action_fallback KjerSiWeb.FallbackController
 
-  plug KjerSiWeb.Plugs.Auth, "is_admin" when action in [:delete]
-
   def create(conn, %{"room" => room_params}) do
     with {:ok, %Room{} = room} <- Rooms.create_room(room_params) do
       conn
@@ -22,10 +20,6 @@ defmodule KjerSiWeb.RoomController do
     with {:ok, %Room{}} <- Rooms.delete_room(room) do
       send_resp(conn, :no_content, "")
     end
-  end
-
-  def show(conn, %{"id" => id}) do
-    render(conn, "room.json", room: Rooms.get_room!(id, [:users]))
   end
 
   def categories(conn, _params) do

--- a/backend/lib/kjer_si_web/controllers/room_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/room_controller.ex
@@ -14,14 +14,6 @@ defmodule KjerSiWeb.RoomController do
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    room = Rooms.get_room!(id)
-
-    with {:ok, %Room{}} <- Rooms.delete_room(room) do
-      send_resp(conn, :no_content, "")
-    end
-  end
-
   def categories(conn, _params) do
     conn
     |> put_view(KjerSiWeb.CategoryView)

--- a/backend/lib/kjer_si_web/controllers/user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/user_controller.ex
@@ -8,9 +8,6 @@ defmodule KjerSiWeb.UserController do
 
   action_fallback KjerSiWeb.FallbackController
 
-  plug KjerSiWeb.Plugs.Auth, "is_admin" when action in [:index, :delete]
-  plug KjerSiWeb.Plugs.Auth, "is_self" when action in [:show]
-
   def index(conn, _params) do
     users = Accounts.list_users()
     render(conn, "index.json", users: users)
@@ -23,11 +20,6 @@ defmodule KjerSiWeb.UserController do
       |> put_resp_header("location", Routes.user_path(conn, :show, user))
       |> render("show.json", user: user)
     end
-  end
-
-  def show(conn, %{"id" => id}) do
-    user = Accounts.get_user!(id)
-    render(conn, "show.json", user: user)
   end
 
   def update(conn, %{"id" => id, "user" => user_params}) do

--- a/backend/lib/kjer_si_web/controllers/user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/user_controller.ex
@@ -8,29 +8,11 @@ defmodule KjerSiWeb.UserController do
 
   action_fallback KjerSiWeb.FallbackController
 
-  def index(conn, _params) do
-    users = Accounts.list_users()
-    render(conn, "index.json", users: users)
-  end
-
   def create(conn, %{"user" => user_params}) do
     with {:ok, %User{} = user} <- Accounts.create_user(user_params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", Routes.user_path(conn, :show, user))
       |> render("show.json", user: user)
-    end
-  end
-
-  def update(conn, %{"id" => id, "user" => user_params}) do
-    user = Accounts.get_user!(id)
-
-    if Map.has_key?(user_params, "is_active") and not AccountsHelpers.is_admin(conn) do
-      AccountsHelpers.return_error(conn, :forbidden)
-    else
-      with {:ok, %User{} = user} <- Accounts.update_user(user, user_params) do
-        render(conn, "show.json", user: user)
-      end
     end
   end
 

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -5,17 +5,30 @@ defmodule KjerSiWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :admin do
+    plug KjerSiWeb.Plugs.Auth, "is_admin"
+  end
+
   scope "/api", KjerSiWeb do
     pipe_through :api
-    resources "/users", UserController, param: "id", except: [:new, :edit]
-    resources "/subscriptions", UserRoomController, only: [:index, :create, :show, :delete]
-    resources "/events", EventController, param: "uid", only: [:index, :show, :create, :update]
-    resources "/eventsubscriptions", UserEventController, only: [:index, :create, :delete]
-    resources "/rooms", RoomController, only: [:create, :delete, :show]
 
-    get "/categories", RoomController, :categories
+    resources "/subscriptions", UserRoomController, only: [:index, :create, :show, :delete]
+    # resources "/eventsubscriptions", UserEventController, only: [:index, :create, :delete] # commenting out, because it's not used yet
+
+    post "/users", UserController, :create # registration
     get "/generate-username", UserController, :generate_username
     post "/recover-self", UserController, :recover_self
+    get "/categories", RoomController, :categories
+    post "/rooms", RoomController, :create
     post "/map/rooms", MapController, :get_rooms_in_radius
+
+    # scope "/admin", Admin do # consider moving controller into Admin module
+    scope "/admin" do
+      pipe_through :admin
+
+      resources "/users", UserController, only: [:index, :edit] # list & deactivate
+      # resources "/events", EventController, param: "uid", only: [:index, :show, :create, :update] # commenting out, because it's not used yet
+      resources "/rooms", RoomController, only: [:delete]
+    end
   end
 end

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -13,9 +13,11 @@ defmodule KjerSiWeb.Router do
     pipe_through :api
 
     resources "/subscriptions", UserRoomController, only: [:index, :create, :show, :delete]
+
     # resources "/eventsubscriptions", UserEventController, only: [:index, :create, :delete] # commenting out, because it's not used yet
 
-    post "/users", UserController, :create # registration
+    # registration
+    post "/users", UserController, :create
     get "/generate-username", UserController, :generate_username
     post "/recover-self", UserController, :recover_self
     get "/categories", RoomController, :categories
@@ -23,12 +25,14 @@ defmodule KjerSiWeb.Router do
     post "/map/rooms", MapController, :get_rooms_in_radius
 
     # scope "/admin", Admin do # consider moving controller into Admin module
-    scope "/admin" do
+    scope "/admin", Admin do
       pipe_through :admin
 
-      resources "/users", UserController, only: [:index, :edit] # list & deactivate
+      # list & deactivate
+      resources "/users", AdminUserController, only: [:index, :update]
+
       # resources "/events", EventController, param: "uid", only: [:index, :show, :create, :update] # commenting out, because it's not used yet
-      resources "/rooms", RoomController, only: [:delete]
+      resources "/rooms", AdminRoomController, only: [:delete]
     end
   end
 end

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -32,7 +32,7 @@ defmodule KjerSiWeb.Router do
       resources "/users", AdminUserController, only: [:index, :update]
 
       # resources "/events", EventController, param: "uid", only: [:index, :show, :create, :update] # commenting out, because it's not used yet
-      resources "/rooms", AdminRoomController, only: [:delete]
+      resources "/rooms", AdminRoomController, only: [:index, :delete]
     end
   end
 end

--- a/backend/lib/kjer_si_web/views/admin/admin_room_view.ex
+++ b/backend/lib/kjer_si_web/views/admin/admin_room_view.ex
@@ -1,0 +1,19 @@
+defmodule KjerSiWeb.Admin.AdminRoomView do
+  use KjerSiWeb, :view
+
+  def render("index.json", %{rooms: rooms}) do
+    %{data: render_many(rooms, __MODULE__, "room.json", as: :room)}
+  end
+
+  def render("room.json", %{room: room}) do
+    %{
+      id: room.id,
+      name: room.name,
+      radius: room.radius,
+      category_id: room.category_id,
+      lat: room.lat,
+      lng: room.lng,
+      users: render_many(room.users, KjerSiWeb.UserView, "user_nickname.json", as: :user)
+    }
+  end
+end

--- a/backend/lib/kjer_si_web/views/admin/admin_user_view.ex
+++ b/backend/lib/kjer_si_web/views/admin/admin_user_view.ex
@@ -1,0 +1,15 @@
+defmodule KjerSiWeb.Admin.AdminUserView do
+  use KjerSiWeb, :view
+
+  def render("index.json", %{users: users}) do
+    %{data: render_many(users, __MODULE__, "user.json", as: :user)}
+  end
+
+  def render("show.json", %{user: user}) do
+    %{data: render_one(user, __MODULE__, "user.json", as: :user)}
+  end
+
+  def render("user.json", %{user: user}) do
+    %{id: user.id, nickname: user.nickname, uid: user.uid, is_active: user.is_active}
+  end
+end

--- a/backend/lib/kjer_si_web/views/room_view.ex
+++ b/backend/lib/kjer_si_web/views/room_view.ex
@@ -9,7 +9,7 @@ defmodule KjerSiWeb.RoomView do
       category_id: room.category_id,
       lat: room.lat,
       lng: room.lng,
-      users: [],
+      users: []
     }
   end
 

--- a/backend/lib/kjer_si_web/views/user_view.ex
+++ b/backend/lib/kjer_si_web/views/user_view.ex
@@ -1,28 +1,18 @@
 defmodule KjerSiWeb.UserView do
   use KjerSiWeb, :view
-  alias KjerSiWeb.UserView
-
-  def render("index.json", %{users: users}) do
-    %{data: render_many(users, UserView, "user.json")}
-  end
 
   def render("show.json", %{user: user}) do
-    %{data: render_one(user, UserView, "user.json")}
-  end
-
-  def render("user.json", %{user: user}) do
-    %{id: user.id,
-      nickname: user.nickname,
-      uid: user.uid,
-      is_active: user.is_active}
+    %{data: %{id: user.id, nickname: user.nickname, uid: user.uid, is_active: user.is_active}}
   end
 
   def render("user_with_token.json", %{token: token, user: user}) do
-    %{id: user.id,
+    %{
+      id: user.id,
       nickname: user.nickname,
       uid: user.uid,
       is_active: user.is_active,
-      token: token}
+      token: token
+    }
   end
 
   def render("user_id.json", %{user: user}) do

--- a/backend/test/kjer_si/rooms_test.exs
+++ b/backend/test/kjer_si/rooms_test.exs
@@ -81,7 +81,7 @@ defmodule KjerSi.RoomsTest do
     end
 
     test "list_rooms/0 returns all rooms" do
-      room = %{ room_fixture() | lat: 120.5, lng: 120.5 }
+      room = %{ room_fixture() | lat: 120.5, lng: 120.5, users: [] }
       assert Rooms.list_rooms() == [room]
     end
 

--- a/backend/test/kjer_si_web/controllers/admin/admin_room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/admin/admin_room_controller_test.exs
@@ -17,22 +17,17 @@ defmodule KjerSiWeb.Admin.AdminRoomControllerTest do
     {:ok, conn: conn, room: room, admin: admin, user: user, category: category}
   end
 
-  defp login_user(conn, user) do
-    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
-    put_req_header(conn, "authorization", "Bearer #{token}")
-  end
-
   describe "delete" do
     test "regular user can't delete a room", %{conn: conn, user: user, room: room} do
       conn
-      |> login_user(user)
+      |> TestHelper.login_user(user)
       |> delete(Routes.admin_room_path(conn, :delete, room))
       |> json_response(403)
     end
 
     test "admin can delete a room", %{conn: conn, admin: admin, room: room} do
       conn
-      |> login_user(admin)
+      |> TestHelper.login_user(admin)
       |> delete(Routes.admin_room_path(conn, :delete, room))
       |> response(204)
     end
@@ -41,7 +36,7 @@ defmodule KjerSiWeb.Admin.AdminRoomControllerTest do
   describe "index" do
     test "regular user can't list all rooms", %{conn: conn, user: user} do
       conn
-      |> login_user(user)
+      |> TestHelper.login_user(user)
       |> get(Routes.admin_room_path(conn, :index))
       |> json_response(403)
     end
@@ -49,7 +44,7 @@ defmodule KjerSiWeb.Admin.AdminRoomControllerTest do
     test "admin can list all rooms", %{conn: conn, admin: admin} do
       %{"data" => [%{"lat" => 10.0, "lng" => 2.0}]} =
         conn
-        |> login_user(admin)
+        |> TestHelper.login_user(admin)
         |> get(Routes.admin_room_path(conn, :index))
         |> json_response(200)
     end

--- a/backend/test/kjer_si_web/controllers/admin/admin_room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/admin/admin_room_controller_test.exs
@@ -1,0 +1,57 @@
+defmodule KjerSiWeb.Admin.AdminRoomControllerTest do
+  use KjerSiWeb.ConnCase
+
+  alias KjerSi.Repo
+  alias KjerSi.Accounts.User
+  alias KjerSi.Rooms.Room
+  alias KjerSi.Rooms.Category
+
+  setup %{conn: conn} do
+    admin = Repo.insert!(%User{nickname: "admin", uid: "1", is_admin: true})
+    user = Repo.insert!(%User{nickname: "user", uid: "2", is_admin: false})
+    category = Repo.insert!(%Category{name: "Test category"})
+
+    room =
+      Repo.insert!(%Room{name: "Test room", category: category, lat: 10.0, lng: 2.0, radius: 10})
+
+    {:ok, conn: conn, room: room, admin: admin, user: user, category: category}
+  end
+
+  defp login_user(conn, user) do
+    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  describe "delete" do
+    test "regular user can't delete a room", %{conn: conn, user: user, room: room} do
+      conn
+      |> login_user(user)
+      |> delete(Routes.admin_room_path(conn, :delete, room))
+      |> json_response(403)
+    end
+
+    test "admin can delete a room", %{conn: conn, admin: admin, room: room} do
+      conn
+      |> login_user(admin)
+      |> delete(Routes.admin_room_path(conn, :delete, room))
+      |> response(204)
+    end
+  end
+
+  describe "index" do
+    test "regular user can't list all rooms", %{conn: conn, user: user} do
+      conn
+      |> login_user(user)
+      |> get(Routes.admin_room_path(conn, :index))
+      |> json_response(403)
+    end
+
+    test "admin can list all rooms", %{conn: conn, admin: admin} do
+      %{"data" => [%{"lat" => 10.0, "lng" => 2.0}]} =
+        conn
+        |> login_user(admin)
+        |> get(Routes.admin_room_path(conn, :index))
+        |> json_response(200)
+    end
+  end
+end

--- a/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
@@ -7,9 +7,8 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
   import Ecto.Query
 
   setup %{conn: conn} do
-    {:ok, admin} = Repo.insert(%User{nickname: "admin", uid: "1", is_admin: true})
-    {:ok, user} = Repo.insert(%User{nickname: "user", uid: "2", is_admin: false})
-
+    admin = Repo.insert!(%User{nickname: "admin", uid: "1", is_admin: true})
+    user = Repo.insert!(%User{nickname: "user", uid: "2", is_admin: false})
     {:ok, conn: conn, admin: admin, user: user}
   end
 

--- a/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
@@ -13,16 +13,11 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
     {:ok, conn: conn, admin: admin, user: user}
   end
 
-  defp login_user(conn, user) do
-    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
-    put_req_header(conn, "authorization", "Bearer #{token}")
-  end
-
   describe "index" do
     test "regular user can't list other users", %{conn: conn, user: user} do
       %{"error" => "Not allowed to perform action"} =
         conn
-        |> login_user(user)
+        |> TestHelper.login_user(user)
         |> get(Routes.admin_user_path(conn, :index))
         |> json_response(403)
     end
@@ -30,7 +25,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
     test "admin user can list other users", %{conn: conn, admin: admin} do
       %{"data" => [%{"nickname" => "admin"}, %{"nickname" => "user"}]} =
         conn
-        |> login_user(admin)
+        |> TestHelper.login_user(admin)
         |> get(Routes.admin_user_path(conn, :index))
         |> json_response(200)
     end
@@ -39,7 +34,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
   describe "update" do
     test "users can't promote themselves to admin", %{conn: conn, user: user} do
       conn
-      |> login_user(user)
+      |> TestHelper.login_user(user)
       |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
       |> json_response(403)
     end
@@ -50,7 +45,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
       assert length(admins) == 1
 
       conn
-      |> login_user(admin)
+      |> TestHelper.login_user(admin)
       |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
       |> json_response(200)
 
@@ -61,7 +56,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
 
     test "user can't deactivate user", %{conn: conn, user: user} do
       conn
-      |> login_user(user)
+      |> TestHelper.login_user(user)
       |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
       |> json_response(403)
     end
@@ -72,7 +67,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
 
       %{"data" => %{"is_active" => false}} =
         conn
-        |> login_user(admin)
+        |> TestHelper.login_user(admin)
         |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
         |> json_response(200)
 
@@ -83,7 +78,7 @@ defmodule KjerSiWeb.Admin.AdminUserControllerTest do
     test "renders errors when data is invalid", %{conn: conn, admin: admin, user: user} do
       %{"errors" => %{"detail" => "Unprocessable Entity"}} =
         conn
-        |> login_user(admin)
+        |> TestHelper.login_user(admin)
         |> put(Routes.admin_user_path(conn, :update, user), user: %{uid: nil})
         |> json_response(422)
     end

--- a/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/admin/admin_user_controller_test.exs
@@ -1,0 +1,91 @@
+defmodule KjerSiWeb.Admin.AdminUserControllerTest do
+  use KjerSiWeb.ConnCase
+
+  alias KjerSi.Repo
+  alias KjerSi.Accounts.User
+
+  import Ecto.Query
+
+  setup %{conn: conn} do
+    {:ok, admin} = Repo.insert(%User{nickname: "admin", uid: "1", is_admin: true})
+    {:ok, user} = Repo.insert(%User{nickname: "user", uid: "2", is_admin: false})
+
+    {:ok, conn: conn, admin: admin, user: user}
+  end
+
+  defp login_user(conn, user) do
+    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+    put_req_header(conn, "authorization", "Bearer #{token}")
+  end
+
+  describe "index" do
+    test "regular user can't list other users", %{conn: conn, user: user} do
+      %{"error" => "Not allowed to perform action"} =
+        conn
+        |> login_user(user)
+        |> get(Routes.admin_user_path(conn, :index))
+        |> json_response(403)
+    end
+
+    test "admin user can list other users", %{conn: conn, admin: admin} do
+      %{"data" => [%{"nickname" => "admin"}, %{"nickname" => "user"}]} =
+        conn
+        |> login_user(admin)
+        |> get(Routes.admin_user_path(conn, :index))
+        |> json_response(200)
+    end
+  end
+
+  describe "update" do
+    test "users can't promote themselves to admin", %{conn: conn, user: user} do
+      conn
+      |> login_user(user)
+      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
+      |> json_response(403)
+    end
+
+    test "not even admin can promote any user to admin", %{conn: conn, user: user, admin: admin} do
+      admins_query = User |> where(is_admin: true)
+      admins = admins_query |> Repo.all()
+      assert length(admins) == 1
+
+      conn
+      |> login_user(admin)
+      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
+      |> json_response(200)
+
+      admins = admins_query |> Repo.all()
+      # if someone adds :is_admin to user.ex changeset, this test should catch it
+      assert length(admins) == 1
+    end
+
+    test "user can't deactivate user", %{conn: conn, user: user} do
+      conn
+      |> login_user(user)
+      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
+      |> json_response(403)
+    end
+
+    test "admin can deactivate user", %{conn: conn, user: user, admin: admin} do
+      deactivated_users = User |> where(is_active: false) |> Repo.all()
+      assert length(deactivated_users) == 0
+
+      %{"data" => %{"is_active" => false}} =
+        conn
+        |> login_user(admin)
+        |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
+        |> json_response(200)
+
+      deactivated_users_after = User |> where(is_active: false) |> Repo.all()
+      assert length(deactivated_users_after) == 1
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, admin: admin, user: user} do
+      %{"errors" => %{"detail" => "Unprocessable Entity"}} =
+        conn
+        |> login_user(admin)
+        |> put(Routes.admin_user_path(conn, :update, user), user: %{uid: nil})
+        |> json_response(422)
+    end
+  end
+end

--- a/backend/test/kjer_si_web/controllers/room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/room_controller_test.exs
@@ -17,16 +17,11 @@ defmodule KjerSiWeb.RoomControllerTest do
     {:ok, conn: conn, room: room, admin: admin, user: user, category: category}
   end
 
-  defp login_user(conn, user) do
-    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
-    put_req_header(conn, "authorization", "Bearer #{token}")
-  end
-
   describe "create" do
     test "regular user can create a room", %{conn: conn, user: user, category: category} do
       %{"name" => "New room", "radius" => 5} =
         conn
-        |> login_user(user)
+        |> TestHelper.login_user(user)
         |> post(
           Routes.room_path(conn, :create),
           room: %{name: "New room", lat: 10.1, lng: 2.3, radius: 5, category_id: category.id}
@@ -39,7 +34,7 @@ defmodule KjerSiWeb.RoomControllerTest do
     test "any user can list room categories", %{conn: conn, user: user} do
       %{"categories" => [%{"name" => "Test category"}]} =
         conn
-        |> login_user(user)
+        |> TestHelper.login_user(user)
         |> get(Routes.room_path(conn, :categories))
         |> json_response(200)
     end

--- a/backend/test/kjer_si_web/controllers/room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/room_controller_test.exs
@@ -35,39 +35,6 @@ defmodule KjerSiWeb.RoomControllerTest do
     end
   end
 
-  describe "delete" do
-    test "regular user can't delete a room", %{conn: conn, user: user, room: room} do
-      conn
-      |> login_user(user)
-      |> delete(Routes.admin_room_path(conn, :delete, room))
-      |> json_response(403)
-    end
-
-    test "admin can delete a room", %{conn: conn, admin: admin, room: room} do
-      conn
-      |> login_user(admin)
-      |> delete(Routes.admin_room_path(conn, :delete, room))
-      |> response(204)
-    end
-  end
-
-  describe "index" do
-    test "regular user can't list all rooms", %{conn: conn, user: user} do
-      conn
-      |> login_user(user)
-      |> get(Routes.admin_room_path(conn, :index))
-      |> json_response(403)
-    end
-
-    test "admin can list all rooms", %{conn: conn, admin: admin} do
-      %{"data" => [%{"lat" => 10.0, "lng" => 2.0}]} =
-        conn
-        |> login_user(admin)
-        |> get(Routes.admin_room_path(conn, :index))
-        |> json_response(200)
-    end
-  end
-
   describe "categories" do
     test "any user can list room categories", %{conn: conn, user: user} do
       %{"categories" => [%{"name" => "Test category"}]} =

--- a/backend/test/kjer_si_web/controllers/room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/room_controller_test.exs
@@ -39,24 +39,31 @@ defmodule KjerSiWeb.RoomControllerTest do
     test "regular user can't delete a room", %{conn: conn, user: user, room: room} do
       conn
       |> login_user(user)
-      |> delete(Routes.room_path(conn, :delete, room))
+      |> delete(Routes.admin_room_path(conn, :delete, room))
       |> json_response(403)
     end
 
     test "admin can delete a room", %{conn: conn, admin: admin, room: room} do
       conn
       |> login_user(admin)
-      |> delete(Routes.room_path(conn, :delete, room))
+      |> delete(Routes.admin_room_path(conn, :delete, room))
       |> response(204)
     end
   end
 
-  describe "show" do
-    test "any user can see a room if they know an id", %{conn: conn, user: user, room: room} do
-      %{"name" => "Test room"} =
+  describe "index" do
+    test "regular user can't list all rooms", %{conn: conn, user: user} do
+      conn
+      |> login_user(user)
+      |> get(Routes.admin_room_path(conn, :index))
+      |> json_response(403)
+    end
+
+    test "admin can list all rooms", %{conn: conn, admin: admin} do
+      %{"data" => [%{"lat" => 10.0, "lng" => 2.0}]} =
         conn
-        |> login_user(user)
-        |> get(Routes.room_path(conn, :show, room))
+        |> login_user(admin)
+        |> get(Routes.admin_room_path(conn, :index))
         |> json_response(200)
     end
   end

--- a/backend/test/kjer_si_web/controllers/room_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/room_controller_test.exs
@@ -7,14 +7,13 @@ defmodule KjerSiWeb.RoomControllerTest do
   alias KjerSi.Rooms.Category
 
   setup %{conn: conn} do
-    admin = Repo.insert!(%User{nickname: "admin", uid: "1", is_admin: true})
     user = Repo.insert!(%User{nickname: "user", uid: "2", is_admin: false})
     category = Repo.insert!(%Category{name: "Test category"})
 
     room =
       Repo.insert!(%Room{name: "Test room", category: category, lat: 10.0, lng: 2.0, radius: 10})
 
-    {:ok, conn: conn, room: room, admin: admin, user: user, category: category}
+    {:ok, conn: conn, room: room, user: user, category: category}
   end
 
   describe "create" do

--- a/backend/test/kjer_si_web/controllers/user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/user_controller_test.exs
@@ -5,8 +5,7 @@ defmodule KjerSiWeb.UserControllerTest do
   alias KjerSi.Accounts.User
 
   setup %{conn: conn} do
-    {:ok, user} = Repo.insert(%User{nickname: "user", uid: "2", is_admin: false})
-
+    user = Repo.insert!(%User{nickname: "user", uid: "2", is_admin: false})
     {:ok, conn: conn, user: user}
   end
 

--- a/backend/test/kjer_si_web/controllers/user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/user_controller_test.exs
@@ -3,117 +3,24 @@ defmodule KjerSiWeb.UserControllerTest do
 
   alias KjerSi.Repo
   alias KjerSi.Accounts.User
-  import Ecto.Query
 
   setup %{conn: conn} do
-    {:ok, admin} = Repo.insert(%User{nickname: "admin", uid: "1", is_admin: true})
     {:ok, user} = Repo.insert(%User{nickname: "user", uid: "2", is_admin: false})
 
-    {:ok, conn: conn, admin: admin, user: user}
-  end
-
-  defp login_user(conn, user) do
-    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
-    put_req_header(conn, "authorization", "Bearer #{token}")
-  end
-
-  describe "index" do
-    test "regular user can't list other users", %{conn: conn, user: user} do
-      %{"error" => "Not allowed to perform action"} =
-        conn
-        |> login_user(user)
-        |> get(Routes.admin_user_path(conn, :index))
-        |> json_response(403)
-    end
-
-    test "admin user can list other users", %{conn: conn, admin: admin} do
-      %{"data" => [%{"nickname" => "admin"}, %{"nickname" => "user"}]} =
-        conn
-        |> login_user(admin)
-        |> get(Routes.admin_user_path(conn, :index))
-        |> json_response(200)
-    end
+    {:ok, conn: conn, user: user}
   end
 
   describe "create" do
-    test "anyone can create new user", %{conn: conn, admin: admin} do
+    test "anyone can create new user", %{conn: conn} do
       conn
       |> post(Routes.user_path(conn, :create), user: %{uid: "42", nickname: "some nickname"})
       |> json_response(201)
-
-      %{"data" => users} =
-        conn
-        |> login_user(admin)
-        |> get(Routes.admin_user_path(conn, :index))
-        |> json_response(200)
-
-      assert [
-               _,
-               _,
-               %{
-                 "uid" => "42",
-                 "nickname" => "some nickname"
-               }
-             ] = users
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       %{"errors" => %{"detail" => "Unprocessable Entity"}} =
         conn
         |> post(Routes.user_path(conn, :create), user: %{uid: nil})
-        |> json_response(422)
-    end
-  end
-
-  describe "update" do
-    test "users can't promote themselves to admin", %{conn: conn, user: user} do
-      conn
-      |> login_user(user)
-      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
-      |> json_response(403)
-    end
-
-    test "not even admin can promote any user to admin", %{conn: conn, user: user, admin: admin} do
-      conn
-      |> login_user(admin)
-      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_admin: true})
-      |> json_response(200)
-
-      admins =
-        User
-        |> where(is_admin: true)
-        |> Repo.all()
-
-      # if someone adds :is_admin to user.ex changeset, this test should catch it
-      assert length(admins) == 1
-    end
-
-    test "user can't deactivate user", %{conn: conn, user: user} do
-      conn
-      |> login_user(user)
-      |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
-      |> json_response(403)
-    end
-
-    test "admin can deactivate user", %{conn: conn, user: user, admin: admin} do
-      deactivated_users = User |> where(is_active: false) |> Repo.all()
-      assert length(deactivated_users) == 0
-
-      %{"data" => %{"is_active" => false}} =
-        conn
-        |> login_user(admin)
-        |> put(Routes.admin_user_path(conn, :update, user), user: %{is_active: false})
-        |> json_response(200)
-
-      deactivated_users_after = User |> where(is_active: false) |> Repo.all()
-      assert length(deactivated_users_after) == 1
-    end
-
-    test "renders errors when data is invalid", %{conn: conn, admin: admin, user: user} do
-      %{"errors" => %{"detail" => "Unprocessable Entity"}} =
-        conn
-        |> login_user(admin)
-        |> put(Routes.admin_user_path(conn, :update, user), user: %{uid: nil})
         |> json_response(422)
     end
   end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -2,6 +2,8 @@ ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(KjerSi.Repo, :manual)
 
 defmodule TestHelper do
+  use KjerSiWeb.ConnCase
+
   def generate_category do
     {:ok, category} = KjerSi.Rooms.create_category(%{
       name: "Test category",
@@ -27,5 +29,10 @@ defmodule TestHelper do
       category_id: test_category.id,
     })
     room
+  end
+
+  def login_user(conn, user) do
+    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+    put_req_header(conn, "authorization", "Bearer #{token}")
   end
 end


### PR DESCRIPTION
@muki @mzgajner 

Tole je meni tbh se bolj vsec, da na router nivoju uporabimo Auth "is_admin" plug in bodo vsi requesti sli preko `/api/admin/...`.

Se bolje bi mi osebno bilo da locimo admin vs non-admin controller-je. Damo vse admin controllerje v svoj module.

Full dober video na tocno to temo ce koga zanima: https://www.youtube.com/watch?v=hnD0Z0LGMIk

## todos

- [x] split/move admin related actions into won module controllers
- [x] remove all not-used routes/actions
- [x] fix tests
- [x] get peer approval for this
- [ ] test with client code!

Main question: al js kar nekaj kompliciram cist prepozno v projektu? Ce se strinjate vsi z gornjo todo listo jo bom js probal ta vikend realizirat.