### PR TITLE
Implement token authentication on sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 docker-compose.override.yml
+.vscode/

--- a/backend/lib/kjer_si/accounts.ex
+++ b/backend/lib/kjer_si/accounts.ex
@@ -38,6 +38,14 @@ defmodule KjerSi.Accounts do
   def get_user!(id), do: Repo.get!(User, id)
 
   @doc """
+  Gets a single user.
+
+  Returns `nil` if the User does not exist.
+
+  """
+  def get_user(id), do: Repo.get(User, id)
+
+  @doc """
   Checks if nickname is unique.
   """
   def unique_nickname?(nickname) do
@@ -49,14 +57,6 @@ defmodule KjerSi.Accounts do
 
   Returns `nil` if the User does not exist.
 
-  ## Examples
-
-      iex> get_user!('asdf')
-      %User{}
-
-      iex> get_user!('fdsa')
-      ** nil
-
   """
   def get_user_by_uid(uid), do: Repo.get_by(User, uid: uid)
 
@@ -65,18 +65,10 @@ defmodule KjerSi.Accounts do
 
   Returns `nil` if the User does not exist.
 
-  ## Examples
-
-      iex> get_user!('asdf')
-      %User{}
-
-      iex> get_user!('fdsa')
-      ** nil
-
   """
   def get_user_with_preload(id, preload) do
     id
-    |> get_user!
+    |> get_user
     |> Repo.preload(preload)
   end
 

--- a/backend/lib/kjer_si_web/channels/chat_channel.ex
+++ b/backend/lib/kjer_si_web/channels/chat_channel.ex
@@ -4,7 +4,7 @@ defmodule KjerSiWeb.ChatChannel do
   use KjerSiWeb, :channel
 
   defp render_message(message) do
-    KjerSiWeb.MessageView.render "message.json", %{message: message}
+    KjerSiWeb.MessageView.render("message.json", %{message: message})
   end
 
   def join("room:" <> _room_id, _payload, socket) do
@@ -33,13 +33,15 @@ defmodule KjerSiWeb.ChatChannel do
 
     # Merge with incoming payload and save to DB
     payload = Map.merge(payload, %{"room_id" => room_id, "user_id" => user_id})
-    {:ok, message} = KjerSi.Messages.Message.changeset(%KjerSi.Messages.Message{}, payload)
-      |> KjerSi.Repo.insert
+
+    {:ok, message} =
+      KjerSi.Messages.Message.changeset(%KjerSi.Messages.Message{}, payload)
+      |> KjerSi.Repo.insert()
 
     message = KjerSi.Repo.preload(message, :user)
 
     # Broadcast back to everyone in the channel
-    broadcast socket, "shout", render_message(message)
+    broadcast(socket, "shout", render_message(message))
 
     {:noreply, socket}
   end
@@ -51,8 +53,10 @@ defmodule KjerSiWeb.ChatChannel do
 
   def handle_info(:after_join, socket) do
     "room:" <> room_id = socket.topic
+
     KjerSi.Messages.Message.get_messages_for_room(room_id)
-      |> Enum.each(fn msg -> push(socket, "shout", render_message(msg)) end)
+    |> Enum.each(fn msg -> push(socket, "shout", render_message(msg)) end)
+
     {:noreply, socket}
   end
 end

--- a/backend/lib/kjer_si_web/channels/user_socket.ex
+++ b/backend/lib/kjer_si_web/channels/user_socket.ex
@@ -15,13 +15,14 @@ defmodule KjerSiWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(%{"user_uid" => user_uid}, socket, _connect_info) do
-    user = KjerSi.Accounts.get_user_by_uid(user_uid)
+  def connect(%{"token" => token}, socket, _connect_info) do
+    case KjerSi.AccountsHelpers.get_user(token) do
+      {:ok, user} ->
+        {:ok, assign(socket, :user_id, user.id)}
 
-    if user do
-      {:ok, assign(socket, :user_id, user.id)}
-    else
-      {:error, %{reason: "user does not exist"}}
+      {:error, error_type} ->
+        error = KjerSi.AccountsHelpers.get_error_from_type(error_type)
+        {:error, %{reason: error.message}}
     end
   end
 

--- a/backend/lib/kjer_si_web/channels/user_socket.ex
+++ b/backend/lib/kjer_si_web/channels/user_socket.ex
@@ -20,9 +20,11 @@ defmodule KjerSiWeb.UserSocket do
       {:ok, user} ->
         {:ok, assign(socket, :user_id, user.id)}
 
-      {:error, error_type} ->
-        error = KjerSi.AccountsHelpers.get_error_from_type(error_type)
-        {:error, %{reason: error.message}}
+      {:error, _} ->
+        # We could get a more precise error message here with:
+        # KjerSi.AccountsHelpers.get_error_from_type(error_type)
+        # But the docs say we can't return more than :error.
+        :error
     end
   end
 

--- a/backend/lib/kjer_si_web/channels/user_socket.ex
+++ b/backend/lib/kjer_si_web/channels/user_socket.ex
@@ -17,6 +17,7 @@ defmodule KjerSiWeb.UserSocket do
   # performing token verification on connect.
   def connect(%{"user_uid" => user_uid}, socket, _connect_info) do
     user = KjerSi.Accounts.get_user_by_uid(user_uid)
+
     if user do
       {:ok, assign(socket, :user_id, user.id)}
     else

--- a/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
+++ b/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
@@ -49,7 +49,7 @@ defmodule KjerSi.AccountsHelpers do
     end
   end
 
-  def return_error(conn, type) do
+  def get_error_from_type(type) do
     errors = %{
       invalid_auth_header: %{
         message: "Authorization header missing or malformed",
@@ -58,6 +58,10 @@ defmodule KjerSi.AccountsHelpers do
       invalid_token: %{
         message: "Token could not be decoded",
         code: 401
+      },
+      invalid_user: %{
+        message: "User does not exist",
+        code: 403
       },
       forbidden: %{
         message: "Not allowed to perform action",
@@ -69,7 +73,11 @@ defmodule KjerSi.AccountsHelpers do
       }
     }
 
-    error = errors[type]
+    errors[type]
+  end
+
+  def return_error(conn, type) do
+    error = get_error_from_type(type)
 
     conn
     |> put_resp_content_type("application/json")

--- a/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
+++ b/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
@@ -26,6 +26,7 @@ defmodule KjerSi.AccountsHelpers do
   defp get_user(conn, preload \\ []) do
     with {:ok, user_id} <- get_user_id(conn) do
       user = Accounts.get_user_with_preload(user_id, preload)
+
       if user do
         {:ok, user}
       else
@@ -52,27 +53,27 @@ defmodule KjerSi.AccountsHelpers do
     errors = %{
       invalid_auth_header: %{
         message: "Authorization header missing or malformed",
-        code: 401,
+        code: 401
       },
       invalid_token: %{
         message: "Token could not be decoded",
-        code: 401,
+        code: 401
       },
       forbidden: %{
         message: "Not allowed to perform action",
-        code: 403,
+        code: 403
       },
       not_found: %{
         message: "Resource not found",
-        code: 404,
-      },
+        code: 404
+      }
     }
 
     error = errors[type]
 
     conn
-      |> put_resp_content_type("application/json")
-      |> send_resp(error.code, "{\"error\": \"#{error.message}\"}")
-      |> halt()
+    |> put_resp_content_type("application/json")
+    |> send_resp(error.code, "{\"error\": \"#{error.message}\"}")
+    |> halt()
   end
 end

--- a/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
+++ b/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
@@ -3,7 +3,7 @@ defmodule KjerSi.AccountsHelpers do
 
   alias KjerSi.Accounts
 
-  defp get_token(conn) do
+  defp get_token_from_conn(conn) do
     header = conn |> get_req_header("authorization") |> to_string
     match = Regex.named_captures(~r/^Bearer (?<token>[[:ascii:]]+)/, header)
 
@@ -14,17 +14,15 @@ defmodule KjerSi.AccountsHelpers do
     end
   end
 
-  defp get_user_id(conn) do
-    with {:ok, token} <- get_token(conn) do
-      case Phoenix.Token.verify(KjerSiWeb.Endpoint, "user auth", token, max_age: 86400) do
-        {:ok, user_id} -> {:ok, user_id}
-        {:error, _} -> {:error, :invalid_token}
-      end
+  defp get_user_id(token) do
+    case Phoenix.Token.verify(KjerSiWeb.Endpoint, "user auth", token, max_age: 86400) do
+      {:ok, user_id} -> {:ok, user_id}
+      {:error, _} -> {:error, :invalid_token}
     end
   end
 
-  defp get_user(conn, preload \\ []) do
-    with {:ok, user_id} <- get_user_id(conn) do
+  def get_user(token, preload \\ []) do
+    with {:ok, user_id} <- get_user_id(token) do
       user = Accounts.get_user_with_preload(user_id, preload)
 
       if user do
@@ -35,15 +33,21 @@ defmodule KjerSi.AccountsHelpers do
     end
   end
 
+  defp get_user_from_conn(conn, preload) do
+    with {:ok, token} <- get_token_from_conn(conn) do
+      get_user(token, preload)
+    end
+  end
+
   def get_auth_user(conn, preload \\ []) do
-    case get_user(conn, preload) do
+    case get_user_from_conn(conn, preload) do
       {:ok, user} -> {:ok, user}
       {:error, error_type} -> return_error(conn, error_type)
     end
   end
 
   def is_admin(conn) do
-    case get_user(conn) do
+    case get_user_from_conn(conn, []) do
       {:ok, user} -> user.is_admin
       {:error, error_type} -> return_error(conn, error_type)
     end

--- a/backend/test/kjer_si_web/accounts_helpers_test.exs
+++ b/backend/test/kjer_si_web/accounts_helpers_test.exs
@@ -1,0 +1,52 @@
+defmodule KjerSiWeb.AccountsHelpersTest do
+  use KjerSiWeb.ConnCase
+
+  alias KjerSi.Repo
+  alias KjerSi.Accounts.User
+  alias KjerSi.AccountsHelpers
+
+  setup %{conn: conn} do
+    {:ok, user} = Repo.insert(%User{nickname: "user", uid: "2", is_admin: false})
+
+    {:ok, conn: conn, user: user}
+  end
+
+  describe "get_auth_user" do
+    test "not providing an auth header returns error", %{conn: conn} do
+      %{"error" => "Authorization header missing or malformed"} =
+        conn
+        |> AccountsHelpers.get_auth_user()
+        |> json_response(401)
+    end
+
+    test "using an invalid token returns error", %{conn: conn} do
+      %{"error" => "Token could not be decoded"} =
+        conn
+        |> put_req_header("authorization", "Bearer Schmearer")
+        |> AccountsHelpers.get_auth_user()
+        |> json_response(401)
+    end
+
+    test "using a valid token with an non-existent user id returns error", %{conn: conn} do
+      non_existent_id = "f4f4f4f4-f4f4-f4f4-f4f4-f4f4f4f4f4f4"
+      valid_token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", non_existent_id)
+
+      %{"error" => "User does not exist"} =
+        conn
+        |> put_req_header("authorization", "Bearer #{valid_token}")
+        |> AccountsHelpers.get_auth_user()
+        |> json_response(403)
+    end
+
+    test "using a valid token with a valid user id returns user", %{conn: conn, user: user} do
+      valid_token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+
+      {:ok, returned_user} =
+        conn
+        |> put_req_header("authorization", "Bearer #{valid_token}")
+        |> AccountsHelpers.get_auth_user()
+
+      assert returned_user == user
+    end
+  end
+end

--- a/backend/test/kjer_si_web/channels/user_socket_test.exs
+++ b/backend/test/kjer_si_web/channels/user_socket_test.exs
@@ -1,0 +1,21 @@
+defmodule KjerSiWeb.UserSocketTest do
+  use KjerSiWeb.ChannelCase
+  alias KjerSiWeb.UserSocket
+
+  setup do
+    user = TestHelper.generate_user()
+
+    {:ok, user: user}
+  end
+
+  test "authenticating with valid token succeeds and assigns user_id", %{user: user} do
+    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+
+    assert {:ok, socket} = connect(UserSocket, %{"token" => token})
+    assert socket.assigns.user_id == user.id
+  end
+
+  test "authenticating with invalid token fails" do
+    assert :error = connect(UserSocket, %{"token" => "invalid-token"})
+  end
+end


### PR DESCRIPTION
Dosedaj smo čisto za potrebe testiranja pustili, da se kdorkoli connecta na socket in kar passa nek `user.uid`. Zdaj je treba namesto tega poslati veljaven token, tako da se lahko connectajo samo authenticated userji.

Večina dela je premetavanje helperjev za getanje userja - prej je bilo vse couplano na request flow, zdaj pa ne več, ker lahko token dobiš na več načinov.