### PR TITLE
Implement `users/self` api endpoint

### DIFF
--- a/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
+++ b/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
@@ -33,12 +33,13 @@ defmodule KjerSi.AccountsHelpers do
     end
   end
 
-  defp get_user_from_conn(conn, preload) do
+  def get_user_from_conn(conn, preload \\ []) do
     with {:ok, token} <- get_token_from_conn(conn) do
       get_user(token, preload)
     end
   end
 
+  # TODO: Remove this and replace with :auth plug everywhere
   def get_auth_user(conn, preload \\ []) do
     case get_user_from_conn(conn, preload) do
       {:ok, user} -> {:ok, user}

--- a/backend/lib/kjer_si_web/controllers/user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/user_controller.ex
@@ -32,4 +32,9 @@ defmodule KjerSiWeb.UserController do
     # Phoenix.Token.verify(MyApp.Endpoint, "user auth", token, max_age: 86400)
     render(conn, "user_with_token.json", %{token: token, user: user})
   end
+
+  def self(conn, _params) do
+    conn
+    |> render("show.json", user: conn.assigns[:current_user])
+  end
 end

--- a/backend/lib/kjer_si_web/plugs/auth.ex
+++ b/backend/lib/kjer_si_web/plugs/auth.ex
@@ -1,4 +1,6 @@
 defmodule KjerSiWeb.Plugs.Auth do
+  import Plug.Conn
+
   alias KjerSi.AccountsHelpers
   alias KjerSi.Accounts.User
 
@@ -9,6 +11,17 @@ defmodule KjerSiWeb.Plugs.Auth do
       conn
     else
       AccountsHelpers.return_error(conn, :forbidden)
+    end
+  end
+
+  def call(conn, "is_logged_in") do
+    case AccountsHelpers.get_user_from_conn(conn) do
+      {:ok, current_user} ->
+        conn
+        |> assign(:current_user, current_user)
+
+      {:error, error_type} ->
+        AccountsHelpers.return_error(conn, error_type)
     end
   end
 

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -5,6 +5,10 @@ defmodule KjerSiWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :auth do
+    plug KjerSiWeb.Plugs.Auth, "is_logged_in"
+  end
+
   pipeline :admin do
     plug KjerSiWeb.Plugs.Auth, "is_admin"
   end
@@ -16,7 +20,12 @@ defmodule KjerSiWeb.Router do
 
     # resources "/eventsubscriptions", UserEventController, only: [:index, :create, :delete] # commenting out, because it's not used yet
 
-    # registration
+    scope "/" do
+      pipe_through :auth
+
+      get "/users/self", UserController, :self
+    end
+
     post "/users", UserController, :create
     get "/generate-username", UserController, :generate_username
     post "/recover-self", UserController, :recover_self

--- a/backend/lib/kjer_si_web/views/user_view.ex
+++ b/backend/lib/kjer_si_web/views/user_view.ex
@@ -2,7 +2,16 @@ defmodule KjerSiWeb.UserView do
   use KjerSiWeb, :view
 
   def render("show.json", %{user: user}) do
-    %{data: %{id: user.id, nickname: user.nickname, uid: user.uid, is_active: user.is_active}}
+    %{
+      data: %{
+        id: user.id,
+        nickname: user.nickname,
+        uid: user.uid,
+        isActive: user.is_active,
+        isAdmin: user.is_admin,
+        createdAt: user.inserted_at
+      }
+    }
   end
 
   def render("user_with_token.json", %{token: token, user: user}) do

--- a/backend/test/kjer_si_web/controllers/user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/user_controller_test.exs
@@ -24,6 +24,23 @@ defmodule KjerSiWeb.UserControllerTest do
     end
   end
 
+  describe "self" do
+    test "returns themselves to authenticated user", %{conn: conn, user: user} do
+      %{"data" => %{"nickname" => "user", "uid" => "2"}} =
+        conn
+        |> TestHelper.login_user(user)
+        |> get(Routes.user_path(conn, :self))
+        |> json_response(200)
+    end
+
+    test "fails for unauthenticated calls", %{conn: conn} do
+      %{"error" => "Authorization header missing or malformed"} =
+        conn
+        |> get(Routes.user_path(conn, :self))
+        |> json_response(401)
+    end
+  end
+
   describe "recover self" do
     test "generates token", %{conn: conn, user: user} do
       %{"token" => token} =


### PR DESCRIPTION
Začenjam implementat spremembe APIja, o katerih smo včeraj debatirali. Ta PR doda nov endpoint `/users/self`, ki vrne logiranega userja.

Auth check sem naredil s plugom po vzoru @zigomir, bom sproti tudi druge applicable endpointe prestavil na ta sistem, toliko da bo enovit error handling.