### PR TITLE
Implement endpoint for user registration/login

### DIFF
--- a/backend/lib/kjer_si_web/controllers/user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/user_controller.ex
@@ -16,23 +16,6 @@ defmodule KjerSiWeb.UserController do
     end
   end
 
-  def generate_username(conn, _params) do
-    # generate nickname and assign to user here TODO
-    name = UserHelpers.generate_unique_name()
-    send_resp(conn, :ok, name)
-  end
-
-  def recover_self(conn, %{"uid" => uid}) do
-    user = Accounts.get_user_by_uid(uid)
-
-    # It's ok for the salt to be hardcoded
-    # https://elixirforum.com/t/phoenix-token-for-api-auth-salt-per-user-or-per-app/13361
-    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
-
-    # Phoenix.Token.verify(MyApp.Endpoint, "user auth", token, max_age: 86400)
-    render(conn, "user_with_token.json", %{token: token, user: user})
-  end
-
   def self(conn, _params) do
     conn
     |> render("show.json", user: conn.assigns[:current_user])

--- a/backend/lib/kjer_si_web/controllers/user_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/user_controller.ex
@@ -3,16 +3,39 @@ defmodule KjerSiWeb.UserController do
 
   alias KjerSi.Accounts
   alias KjerSi.Accounts.User
-  alias KjerSi.AccountsHelpers
   alias KjerSi.UserHelpers
 
   action_fallback KjerSiWeb.FallbackController
 
-  def create(conn, %{"user" => user_params}) do
+  def create(conn, %{"uid" => uid}) do
+    user = Accounts.get_user_by_uid(uid)
+
+    if user do
+      login(conn, user)
+    else
+      register(conn, uid)
+    end
+  end
+
+  defp login(conn, user) do
+    # It's ok for the salt to be hardcoded
+    # https://elixirforum.com/t/phoenix-token-for-api-auth-salt-per-user-or-per-app/13361
+    token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
+
+    conn
+    |> render("user_with_token.json", %{token: token, user: user})
+  end
+
+  defp register(conn, uid) do
+    user_params = %{
+      "nickname" => UserHelpers.generate_unique_name(),
+      "uid" => uid
+    }
+
     with {:ok, %User{} = user} <- Accounts.create_user(user_params) do
-      conn
-      |> put_status(:created)
-      |> render("show.json", user: user)
+      conn = Plug.Conn.put_status(conn, :created)
+
+      login(conn, user)
     end
   end
 

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -27,8 +27,6 @@ defmodule KjerSiWeb.Router do
     end
 
     post "/users", UserController, :create
-    get "/generate-username", UserController, :generate_username
-    post "/recover-self", UserController, :recover_self
     get "/categories", RoomController, :categories
     post "/rooms", RoomController, :create
     post "/map/rooms", MapController, :get_rooms_in_radius

--- a/backend/lib/kjer_si_web/views/user_view.ex
+++ b/backend/lib/kjer_si_web/views/user_view.ex
@@ -16,11 +16,15 @@ defmodule KjerSiWeb.UserView do
 
   def render("user_with_token.json", %{token: token, user: user}) do
     %{
-      id: user.id,
-      nickname: user.nickname,
-      uid: user.uid,
-      is_active: user.is_active,
-      token: token
+      data: %{
+        id: user.id,
+        nickname: user.nickname,
+        uid: user.uid,
+        isActive: user.is_active,
+        isAdmin: user.is_admin,
+        createdAt: user.inserted_at,
+        token: token,
+      }
     }
   end
 

--- a/backend/test/kjer_si_web/controllers/user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/user_controller_test.exs
@@ -10,16 +10,45 @@ defmodule KjerSiWeb.UserControllerTest do
   end
 
   describe "create" do
-    test "anyone can create new user", %{conn: conn} do
-      conn
-      |> post(Routes.user_path(conn, :create), user: %{uid: "42", nickname: "some nickname"})
-      |> json_response(201)
+    test "performs login for existing uids", %{conn: conn} do
+      users_before = TestHelper.get_user_count()
+
+      %{"data" => %{"nickname" => "user"}} =
+        conn
+        |> post(Routes.user_path(conn, :create), uid: "2")
+        |> json_response(200)
+
+      users_after = TestHelper.get_user_count()
+
+      assert users_after == users_before
+    end
+
+    test "returns token upon successful login", %{conn: conn} do
+      %{"data" => %{"token" => token}} =
+        conn
+        |> post(Routes.user_path(conn, :create), uid: "2")
+        |> json_response(200)
+
+      assert String.length(token) == 148
+    end
+
+    test "performs registration for new uids", %{conn: conn} do
+      users_before = TestHelper.get_user_count()
+
+      %{"data" => %{"uid" => "1337"}} =
+        conn
+        |> post(Routes.user_path(conn, :create), uid: "1337")
+        |> json_response(201)
+
+      users_after = TestHelper.get_user_count()
+
+      assert users_after == users_before + 1
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       %{"errors" => %{"detail" => "Unprocessable Entity"}} =
         conn
-        |> post(Routes.user_path(conn, :create), user: %{uid: nil})
+        |> post(Routes.user_path(conn, :create), uid: "")
         |> json_response(422)
     end
   end

--- a/backend/test/kjer_si_web/controllers/user_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/user_controller_test.exs
@@ -40,19 +40,4 @@ defmodule KjerSiWeb.UserControllerTest do
         |> json_response(401)
     end
   end
-
-  describe "recover self" do
-    test "generates token", %{conn: conn, user: user} do
-      %{"token" => token} =
-        conn
-        |> post(Routes.user_path(conn, :recover_self), %{uid: user.uid})
-        |> json_response(200)
-
-      assert String.length(token) == 148
-
-      assert_error_sent 404, fn ->
-        get(conn, Routes.user_path(conn, :recover_self), %{uid: user.uid})
-      end
-    end
-  end
 end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -5,29 +5,36 @@ defmodule TestHelper do
   use KjerSiWeb.ConnCase
 
   def generate_category do
-    {:ok, category} = KjerSi.Rooms.create_category(%{
-      name: "Test category",
-    })
+    {:ok, category} =
+      KjerSi.Rooms.create_category(%{
+        name: "Test category"
+      })
+
     category
   end
 
   def generate_user do
-    {:ok, user} = KjerSi.Accounts.create_user(%{
-      nickname: "TestNickname",
-      uid: "1337",
-    })
+    {:ok, user} =
+      KjerSi.Accounts.create_user(%{
+        nickname: "TestNickname",
+        uid: "1337"
+      })
+
     user
   end
 
   def generate_room do
     test_category = generate_category()
-    {:ok, room} = KjerSi.Rooms.create_room(%{
-      lat: 120.5,
-      lng: 120.5,
-      name: "some name",
-      radius: 42,
-      category_id: test_category.id,
-    })
+
+    {:ok, room} =
+      KjerSi.Rooms.create_room(%{
+        lat: 120.5,
+        lng: 120.5,
+        name: "some name",
+        radius: 42,
+        category_id: test_category.id
+      })
+
     room
   end
 

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -42,4 +42,9 @@ defmodule TestHelper do
     token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
     put_req_header(conn, "authorization", "Bearer #{token}")
   end
+
+  def get_user_count do
+    users = KjerSi.Accounts.User |> KjerSi.Repo.all()
+    length(users)
+  end
 end


### PR DESCRIPTION
Nadaljujem prilagajanje APIja po Francijevem Postman specu

- `POST /users` endpoint je zdaj namenjen loginu/registraciji, v bodyju pričakuje `{ "uid": 123 }`. Če postneš obstoječ uid, se prijaviš, če novega, se tudi registriraš. Response je v vsakem primeru enak in vsebuje podatke o userju ter token.
- Odstranjena sta endpointa `/generate-username` in `/recover-self`. Prvi ni več potreben, ker registracija avtomatsko zgenerira random nickname s Filipovo kodo, druga tudi ne, ker je služila loginu oz. generiranju tokena.