### PR TITLE
Don't return user if it's not active

### DIFF
--- a/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
+++ b/backend/lib/kjer_si_web/controllers/helpers/accounts_helpers.ex
@@ -25,7 +25,7 @@ defmodule KjerSi.AccountsHelpers do
     with {:ok, user_id} <- get_user_id(token) do
       user = Accounts.get_user_with_preload(user_id, preload)
 
-      if user do
+      if user && user.is_active do
         {:ok, user}
       else
         {:error, :invalid_user}


### PR DESCRIPTION
@mzgajner nekej takega? Manjkajo se testi.

Vem da si omenil, da bi lahko tko kot z ostalimi Auth plug funkcijam resil, sam sm razmislal da ce user ni active pol nima kej `AccountsHelpers.get_user` kej vracat. Ampak maybe sm kej sfalil :)