### PR TITLE
Fixi za listanje messagev

### DIFF
--- a/backend/lib/kjer_si/accounts/subscription.ex
+++ b/backend/lib/kjer_si/accounts/subscription.ex
@@ -8,7 +8,7 @@ defmodule KjerSi.Accounts.Subscription do
     belongs_to :user, KjerSi.Accounts.User
     belongs_to :room, KjerSi.Rooms.Room
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/accounts/user.ex
+++ b/backend/lib/kjer_si/accounts/user.ex
@@ -16,7 +16,7 @@ defmodule KjerSi.Accounts.User do
 
     many_to_many :events, KjerSi.Events.Event, join_through: KjerSi.Events.UserEvent, unique: true
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/events/event.ex
+++ b/backend/lib/kjer_si/events/event.ex
@@ -15,7 +15,7 @@ defmodule KjerSi.Events.Event do
 
     many_to_many :users, KjerSi.Accounts.User, join_through: KjerSi.Events.UserEvent, unique: true
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/events/user_event.ex
+++ b/backend/lib/kjer_si/events/user_event.ex
@@ -8,7 +8,7 @@ defmodule KjerSi.Events.UserEvent do
     belongs_to :user, KjerSi.Accounts.User
     belongs_to :event, KjerSi.Events.Event
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/messages.ex
+++ b/backend/lib/kjer_si/messages.ex
@@ -20,8 +20,10 @@ defmodule KjerSi.Messages do
   def list_messages(room_id, before, limit) do
     Message
     |> where([m], m.inserted_at < ^before and m.room_id == ^room_id)
+    |> order_by([m], desc: m.inserted_at)
     |> limit([m], ^limit)
     |> Repo.all()
     |> Repo.preload([:user])
+    |> Enum.reverse()
   end
 end

--- a/backend/lib/kjer_si/messages/message.ex
+++ b/backend/lib/kjer_si/messages/message.ex
@@ -10,7 +10,7 @@ defmodule KjerSi.Messages.Message do
     belongs_to :room, KjerSi.Rooms.Room
     belongs_to :user, KjerSi.Accounts.User
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/rooms/category.ex
+++ b/backend/lib/kjer_si/rooms/category.ex
@@ -7,7 +7,7 @@ defmodule KjerSi.Rooms.Category do
   schema "categories" do
     field :name, :string
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/lib/kjer_si/rooms/room.ex
+++ b/backend/lib/kjer_si/rooms/room.ex
@@ -18,7 +18,7 @@ defmodule KjerSi.Rooms.Room do
       join_through: KjerSi.Accounts.Subscription,
       unique: true
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc false

--- a/backend/postman_collection.json
+++ b/backend/postman_collection.json
@@ -821,19 +821,19 @@
 							}
 						},
 						"url": {
-							"raw": "{{base}}/rooms/7d06cf8c-a623-4bb3-9617-6638385ccd5f/messages?before=2020-03-23T10:58:36&limit=100",
+							"raw": "{{base}}/rooms/19327674-2b83-4336-b7b5-4264c6eda082/messages?before=2020-04-23T10:58:36&limit=100",
 							"host": [
 								"{{base}}"
 							],
 							"path": [
 								"rooms",
-								"7d06cf8c-a623-4bb3-9617-6638385ccd5f",
+								"19327674-2b83-4336-b7b5-4264c6eda082",
 								"messages"
 							],
 							"query": [
 								{
 									"key": "before",
-									"value": "2020-03-23T10:58:36"
+									"value": "2020-04-23T10:58:36"
 								},
 								{
 									"key": "limit",
@@ -852,7 +852,7 @@
 						},
 						{
 							"key": "content-length",
-							"value": "704"
+							"value": "728"
 						},
 						{
 							"key": "content-type",
@@ -860,7 +860,7 @@
 						},
 						{
 							"key": "date",
-							"value": "Tue, 24 Mar 2020 18:51:19 GMT"
+							"value": "Wed, 08 Apr 2020 16:52:59 GMT"
 						},
 						{
 							"key": "server",
@@ -868,11 +868,11 @@
 						},
 						{
 							"key": "x-request-id",
-							"value": "Ff9SHXUwOh7F1NkAAAvB"
+							"value": "FgPmXLJmDVkk9y0AAAGB"
 						}
 					],
 					"cookie": [],
-					"body": "{\n    \"data\": [\n        {\n            \"content\": \"kako ste?\",\n            \"created\": \"2020-03-22T16:30:33\",\n            \"id\": \"86b8fd27-85fd-433f-b90c-49cd4b93ad8f\",\n            \"roomId\": \"7d06cf8c-a623-4bb3-9617-6638385ccd5f\",\n            \"userId\": \"3ed05b3c-60a4-41d2-97b5-2064ebf3be3d\",\n            \"userNickname\": \"Polde the Admin\"\n        },\n        {\n            \"content\": \"gre kdo na sprehod?\",\n            \"created\": \"2020-03-22T16:30:33\",\n            \"id\": \"acce49b5-2a7b-47c7-b19e-6f25ac611995\",\n            \"roomId\": \"7d06cf8c-a623-4bb3-9617-6638385ccd5f\",\n            \"userId\": \"3ed05b3c-60a4-41d2-97b5-2064ebf3be3d\",\n            \"userNickname\": \"Polde the Admin\"\n        },\n        {\n            \"content\": \"ja, čez 5 minut\",\n            \"created\": \"2020-03-22T16:30:33\",\n            \"id\": \"a386767c-bca5-44c4-af50-5a97013f8f20\",\n            \"roomId\": \"7d06cf8c-a623-4bb3-9617-6638385ccd5f\",\n            \"userId\": \"4c04ff38-ef55-441f-bf1d-265e210f1c7a\",\n            \"userNickname\": \"Micka\"\n        }\n    ]\n}"
+					"body": "{\n    \"data\": [\n        {\n            \"content\": \"kako ste?\",\n            \"created\": \"2020-04-08T16:31:28.427297Z\",\n            \"id\": \"6ac11c29-a94d-4296-b7f3-7a2f502e8921\",\n            \"roomId\": \"19327674-2b83-4336-b7b5-4264c6eda082\",\n            \"userId\": \"1a203f4b-726f-4466-a30e-5137abd90f43\",\n            \"userNickname\": \"Polde the Admin\"\n        },\n        {\n            \"content\": \"gre kdo na sprehod?\",\n            \"created\": \"2020-04-08T16:31:28.430079Z\",\n            \"id\": \"9d94b3a9-d6fd-44a3-a795-faf04910b9ff\",\n            \"roomId\": \"19327674-2b83-4336-b7b5-4264c6eda082\",\n            \"userId\": \"1a203f4b-726f-4466-a30e-5137abd90f43\",\n            \"userNickname\": \"Polde the Admin\"\n        },\n        {\n            \"content\": \"ja, čez 5 minut\",\n            \"created\": \"2020-04-08T16:31:28.432489Z\",\n            \"id\": \"a3c149bf-b8dc-4094-aff3-22561b8cfd7a\",\n            \"roomId\": \"19327674-2b83-4336-b7b5-4264c6eda082\",\n            \"userId\": \"46f97c56-fb53-4282-889e-c27f58c7ea37\",\n            \"userNickname\": \"Micka\"\n        }\n    ]\n}"
 				}
 			]
 		},
@@ -1127,7 +1127,7 @@
 	],
 	"variable": [
 		{
-			"id": "f619560c-1383-4df4-aa23-a452a4f28704",
+			"id": "4e5af20f-d126-4dd0-8c9b-8789acb1f445",
 			"key": "base",
 			"value": "http://localhost:3088",
 			"type": "string"

--- a/backend/priv/repo/migrations/20191102093740_create_users.exs
+++ b/backend/priv/repo/migrations/20191102093740_create_users.exs
@@ -11,7 +11,7 @@ defmodule KjerSi.Repo.Migrations.CreateUsers do
       add :is_active, :boolean
       add :is_admin, :boolean
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create unique_index(:users, [:nickname])

--- a/backend/priv/repo/migrations/20191129171628_create_categories.exs
+++ b/backend/priv/repo/migrations/20191129171628_create_categories.exs
@@ -6,7 +6,7 @@ defmodule KjerSi.Repo.Migrations.CreateCategories do
       add :id, :binary_id, primary_key: true
       add :name, :string, null: false
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create unique_index(:categories, [:name])

--- a/backend/priv/repo/migrations/20191129172504_create_rooms.exs
+++ b/backend/priv/repo/migrations/20191129172504_create_rooms.exs
@@ -11,7 +11,7 @@ defmodule KjerSi.Repo.Migrations.CreateRooms do
       add :radius, :integer
       add :description, :text, null: false
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     # used to be srid 3857 / 4326

--- a/backend/priv/repo/migrations/20191129204443_create_subscriptions.exs
+++ b/backend/priv/repo/migrations/20191129204443_create_subscriptions.exs
@@ -7,7 +7,7 @@ defmodule KjerSi.Repo.Migrations.CreateSubscriptions do
       add :user_id, references(:users, on_delete: :delete_all, type: :binary_id)
       add :room_id, references(:rooms, on_delete: :delete_all, type: :binary_id)
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create(index(:subscriptions, [:user_id]))

--- a/backend/priv/repo/migrations/20191130085134_create_events.exs
+++ b/backend/priv/repo/migrations/20191130085134_create_events.exs
@@ -12,7 +12,7 @@ defmodule KjerSi.Repo.Migrations.CreateEvents do
       add :user_id, references(:users, on_delete: :nothing, type: :binary_id)
       add :room_id, references(:rooms, on_delete: :nothing, type: :binary_id)
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:events, [:user_id])

--- a/backend/priv/repo/migrations/20191130184230_create_messages.exs
+++ b/backend/priv/repo/migrations/20191130184230_create_messages.exs
@@ -8,7 +8,7 @@ defmodule KjerSi.Repo.Migrations.CreateMessages do
       add :user_id, references(:users, on_delete: :nothing, type: :binary_id)
       add :room_id, references(:rooms, on_delete: :delete_all, type: :binary_id)
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:messages, [:user_id])

--- a/backend/priv/repo/migrations/20191130204446_create_user_event.exs
+++ b/backend/priv/repo/migrations/20191130204446_create_user_event.exs
@@ -7,7 +7,7 @@ defmodule KjerSi.Repo.Migrations.CreateUserEvents do
       add :user_id, references(:users, on_delete: :delete_all, type: :binary_id)
       add :event_id, references(:events, on_delete: :delete_all, type: :binary_id)
 
-      timestamps()
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:users_events, [:user_id])

--- a/backend/test/kjer_si/messages_test.exs
+++ b/backend/test/kjer_si/messages_test.exs
@@ -47,6 +47,23 @@ defmodule KjerSi.MessagesTest do
       assert Messages.list_messages(room_id, past_date, limit) == []
     end
 
+    test "filtering with `before` returns correct results even when messages " <>
+           "are created in the same second as dates use microseconds",
+         %{
+           user_id: user_id,
+           room_id: room_id
+         } do
+      limit = 1000
+
+      message1 = message_fixture(user_id, room_id)
+      message2 = message_fixture(user_id, room_id)
+      message3 = message_fixture(user_id, room_id)
+
+      before_date = DateTime.to_iso8601(message3.inserted_at)
+
+      assert Messages.list_messages(room_id, before_date, limit) == [message1, message2]
+    end
+
     test "list_messages/3 result count can be limited with `limit`",
          %{
            user_id: user_id,

--- a/backend/test/kjer_si/messages_test.exs
+++ b/backend/test/kjer_si/messages_test.exs
@@ -18,10 +18,11 @@ defmodule KjerSi.MessagesTest do
       |> KjerSi.Repo.preload([:user])
     end
 
-    test "list_messages/3 returns a list of messages for given room_id", %{
-      user_id: user_id,
-      room_id: room_id
-    } do
+    test "list_messages/3 returns a list of messages for given room_id sorted by creation date",
+         %{
+           user_id: user_id,
+           room_id: room_id
+         } do
       future_date = "2100-01-01T00:00:00"
       limit = 1000
       irrelevant_room = TestHelper.generate_room()
@@ -46,7 +47,7 @@ defmodule KjerSi.MessagesTest do
       assert Messages.list_messages(room_id, past_date, limit) == []
     end
 
-    test "list_messages/3 result count can be limited with `limit` to return latest n messages",
+    test "list_messages/3 result count can be limited with `limit`",
          %{
            user_id: user_id,
            room_id: room_id
@@ -58,6 +59,27 @@ defmodule KjerSi.MessagesTest do
       message = message_fixture(user_id, room_id)
 
       assert Messages.list_messages(room_id, future_date, limit) == [message]
+    end
+
+    test "list_messages/3 returns latest messages when using `limit`",
+         %{
+           user_id: user_id,
+           room_id: room_id
+         } do
+      future_date = "2100-01-01T00:00:00"
+      limit = 3
+
+      # Older messages that won't be returned
+      message_fixture(user_id, room_id)
+      message_fixture(user_id, room_id)
+      message_fixture(user_id, room_id)
+
+      # Newer messages that will be returned
+      message1 = message_fixture(user_id, room_id)
+      message2 = message_fixture(user_id, room_id)
+      message3 = message_fixture(user_id, room_id)
+
+      assert Messages.list_messages(room_id, future_date, limit) == [message1, message2, message3]
     end
   end
 end

--- a/backend/test/kjer_si/messages_test.exs
+++ b/backend/test/kjer_si/messages_test.exs
@@ -46,15 +46,16 @@ defmodule KjerSi.MessagesTest do
       assert Messages.list_messages(room_id, past_date, limit) == []
     end
 
-    test "list_messages/3 result count can be limited with `limit`", %{
-      user_id: user_id,
-      room_id: room_id
-    } do
+    test "list_messages/3 result count can be limited with `limit` to return latest n messages",
+         %{
+           user_id: user_id,
+           room_id: room_id
+         } do
       future_date = "2100-01-01T00:00:00"
       limit = 1
 
-      message = message_fixture(user_id, room_id)
       message_fixture(user_id, room_id)
+      message = message_fixture(user_id, room_id)
 
       assert Messages.list_messages(room_id, future_date, limit) == [message]
     end

--- a/backend/test/kjer_si_web/controllers/message_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/message_controller_test.exs
@@ -26,6 +26,18 @@ defmodule KjerSiWeb.MessageControllerTest do
         |> json_response(200)
     end
 
+    test "renders datetime with timezone specified", %{conn: conn, room: room} do
+      future_date = "2100-01-01T00:00:00"
+
+      %{"data" => [%{"created" => created_date}, %{}]} =
+        conn
+        |> get(Routes.room_message_path(conn, :index, room.id, before: future_date, limit: 10))
+        |> json_response(200)
+
+      iso_date_with_timezone = "2020-04-08T16:36:18.566937Z"
+      assert String.length(created_date) == String.length(iso_date_with_timezone)
+    end
+
     test "requires before param to be present", %{conn: conn, room: room} do
       %{"errors" => %{"fields" => %{"before" => ["can't be blank"]}}} =
         conn

--- a/backend/test/kjer_si_web/controllers/message_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/message_controller_test.exs
@@ -26,7 +26,7 @@ defmodule KjerSiWeb.MessageControllerTest do
         |> json_response(200)
     end
 
-    test "renders datetime with timezone specified", %{conn: conn, room: room} do
+    test "renders datetime with microseconds and in UTC", %{conn: conn, room: room} do
       future_date = "2100-01-01T00:00:00"
 
       %{"data" => [%{"created" => created_date}, %{}]} =
@@ -34,8 +34,11 @@ defmodule KjerSiWeb.MessageControllerTest do
         |> get(Routes.room_message_path(conn, :index, room.id, before: future_date, limit: 10))
         |> json_response(200)
 
-      iso_date_with_timezone = "2020-04-08T16:36:18.566937Z"
-      assert String.length(created_date) == String.length(iso_date_with_timezone)
+      # This describes an ISO8601 date format with microseconds and UTC explicitly specified
+      # e.g. 2020-04-08T16:36:18.566937Z
+      expected_format = ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z$/
+
+      assert String.match?(created_date, expected_format)
     end
 
     test "requires before param to be present", %{conn: conn, room: room} do


### PR DESCRIPTION
- Datumi so bili doslej naive timestamp, odslej so UTC, kar reši probleme s timezoneom, ki jih je imel @FranciZ na clientu
- Enablal sem varianto z microsecond podporo, ker smo doslej tehnično imeli subtle bug, da če bi insertal 2 messagea ob 12:34:56, potem bi bil pa prvi od teh dveh ravno na meji enega pagea historyja in bi ti requestal več historyja z `before` 12:34:56, bi ti drugega preskočilo.
- Limitiranje je bilo v napačnem vrstnem redu, kot je odkril Franci - zdaj je to fixed in returna najbolj aktualna sporočila.