### PR TITLE
Allow unsubscribe with just room id

### DIFF
--- a/backend/lib/kjer_si/accounts.ex
+++ b/backend/lib/kjer_si/accounts.ex
@@ -173,7 +173,7 @@ defmodule KjerSi.Accounts do
   def get_subscription!(id), do: Repo.get!(Subscription, id)
 
   @doc """
-  Gets a single subscription.
+  Gets a single subscription by id.
 
   ## Examples
 
@@ -192,6 +192,25 @@ defmodule KjerSi.Accounts do
   end
 
   @doc """
+  Gets a single subscription by user_id and room_id.
+
+  ## Examples
+
+      iex> get_subscription(123, 456)
+      {:ok, %Subscription{}}
+
+      iex> get_subscription(456, 789)
+      {:error, :not_found}
+
+  """
+  def get_subscription(user_id, room_id) do
+    case Repo.get_by(Subscription, user_id: user_id, room_id: room_id) do
+      nil -> {:error, :not_found}
+      subscription -> {:ok, subscription}
+    end
+  end
+
+  @doc """
   Unsubscribes user from room.
 
   ## Examples
@@ -203,7 +222,9 @@ defmodule KjerSi.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_subscription(%Subscription{} = subscription) do
-    Repo.delete(subscription)
+  def delete_subscription(id) do
+    with {:ok, %Subscription{} = subscription} <- get_subscription(id) do
+      Repo.delete(subscription)
+    end
   end
 end

--- a/backend/lib/kjer_si_web/controllers/subscription_controller.ex
+++ b/backend/lib/kjer_si_web/controllers/subscription_controller.ex
@@ -49,9 +49,8 @@ defmodule KjerSiWeb.SubscriptionController do
     end
   end
 
-  def delete_by_room_id(conn, params) do
+  def delete_by_room_id(conn, %{"room_id" => room_id}) do
     user_id = conn.assigns[:current_user].id
-    room_id = params["room_id"]
 
     with {:ok, %Subscription{} = subscription} <- Accounts.get_subscription(user_id, room_id) do
       conn

--- a/backend/lib/kjer_si_web/router.ex
+++ b/backend/lib/kjer_si_web/router.ex
@@ -27,6 +27,7 @@ defmodule KjerSiWeb.Router do
 
       resources "/rooms", RoomController, only: [:index, :create, :show] do
         get "/messages", MessageController, :index
+        delete "/subscriptions", SubscriptionController, :delete_by_room_id
       end
     end
 

--- a/backend/postman_collection.json
+++ b/backend/postman_collection.json
@@ -6,7 +6,7 @@
 	},
 	"item": [
 		{
-			"name": "Leave room",
+			"name": "Leave room by subscription id",
 			"request": {
 				"auth": {
 					"type": "bearer",
@@ -54,7 +54,7 @@
 			},
 			"response": [
 				{
-					"name": "Leave room",
+					"name": "Leave room by subscription id",
 					"originalRequest": {
 						"method": "DELETE",
 						"header": [
@@ -80,13 +80,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{base}}/subscriptions/adf6d978-70f5-4cf4-a556-e0d5d00c7694",
+							"raw": "{{base}}/subscriptions/7f59a9cc-cfca-4399-a8c2-081be310314d",
 							"host": [
 								"{{base}}"
 							],
 							"path": [
 								"subscriptions",
-								"adf6d978-70f5-4cf4-a556-e0d5d00c7694"
+								"7f59a9cc-cfca-4399-a8c2-081be310314d"
 							]
 						}
 					},
@@ -100,7 +100,7 @@
 						},
 						{
 							"key": "date",
-							"value": "Tue, 24 Mar 2020 18:07:05 GMT"
+							"value": "Wed, 08 Apr 2020 23:31:33 GMT"
 						},
 						{
 							"key": "server",
@@ -108,7 +108,119 @@
 						},
 						{
 							"key": "x-request-id",
-							"value": "Ff9Ps43o39PZXOsAAAvF"
+							"value": "FgPyUzaN3cvqp4cAAAOH"
+						}
+					],
+					"cookie": [],
+					"body": null
+				}
+			]
+		},
+		{
+			"name": "Leave room by room_id ",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{TOKEN}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"type": "text",
+						"value": "[{\"description\":\"\",\"enabled\":true,\"key\":\"Authorization\",\"type\":\"text\",\"value\":\"{{TOKEN}}\"}]",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{base}}/subscriptions/42965d0a-a280-4f15-98ee-984b36a378ce",
+					"host": [
+						"{{base}}"
+					],
+					"path": [
+						"subscriptions",
+						"42965d0a-a280-4f15-98ee-984b36a378ce"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Leave room by room_id ",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "[{\"description\":\"\",\"enabled\":true,\"key\":\"Authorization\",\"type\":\"text\",\"value\":\"{{TOKEN}}\"}]",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base}}/rooms/e7d1b758-9b32-4a90-a800-d8b978d04e82/subscriptions",
+							"host": [
+								"{{base}}"
+							],
+							"path": [
+								"rooms",
+								"e7d1b758-9b32-4a90-a800-d8b978d04e82",
+								"subscriptions"
+							]
+						}
+					},
+					"status": "No Content",
+					"code": 204,
+					"_postman_previewlanguage": "plain",
+					"header": [
+						{
+							"key": "cache-control",
+							"value": "max-age=0, private, must-revalidate"
+						},
+						{
+							"key": "date",
+							"value": "Wed, 08 Apr 2020 23:30:42 GMT"
+						},
+						{
+							"key": "server",
+							"value": "Cowboy"
+						},
+						{
+							"key": "x-request-id",
+							"value": "FgPyRvbzST4XhAoAAAKH"
 						}
 					],
 					"cookie": [],

--- a/backend/priv/repo/migrations/20191130085134_create_events.exs
+++ b/backend/priv/repo/migrations/20191130085134_create_events.exs
@@ -9,8 +9,8 @@ defmodule KjerSi.Repo.Migrations.CreateEvents do
       add :location, :string
       add :description, :string
       add :max_attending, :integer
-      add :user_id, references(:users, on_delete: :nothing, type: :binary_id)
-      add :room_id, references(:rooms, on_delete: :nothing, type: :binary_id)
+      add :user_id, references(:users, on_delete: :delete_all, type: :binary_id)
+      add :room_id, references(:rooms, on_delete: :delete_all, type: :binary_id)
 
       timestamps(type: :utc_datetime_usec)
     end

--- a/backend/test/kjer_si/accounts_test.exs
+++ b/backend/test/kjer_si/accounts_test.exs
@@ -80,14 +80,32 @@ defmodule KjerSi.AccountsTest do
       assert Accounts.list_subscriptions(user_id) == [subscription]
     end
 
-    test "get_subscrition/1 returns {:ok, subscription} if subscription with given id exists" do
+    test "get_subscription/1 returns {:ok, subscription} if subscription with given id exists" do
       subscription = subscription_fixture()
       assert Accounts.get_subscription(subscription.id) == {:ok, subscription}
     end
 
-    test "get_subscrition/1 returns {:error, :not_found} if subscription with given id does not exist" do
+    test "get_subscription/1 returns {:error, :not_found} if subscription with given id does not exist" do
       fake_id = "ba294533-82b6-4cbb-abc1-167cd7bf4bb1"
       assert Accounts.get_subscription(fake_id) == {:error, :not_found}
+    end
+
+    test "get_subscription/2 returns {:ok, subscription} if subscription exists for given user_id and room_id" do
+      user = TestHelper.generate_user()
+      room = TestHelper.generate_room()
+
+      {:ok, subscription} =
+        Accounts.create_subscription(%{
+          user_id: user.id,
+          room_id: room.id
+        })
+
+      assert Accounts.get_subscription(user.id, room.id) == {:ok, subscription}
+    end
+
+    test "get_subscription/2 returns {:error, :not_found} if subscription doesn't exist for given user_id and room_id" do
+      fake_id = "ba294533-82b6-4cbb-abc1-167cd7bf4bb1"
+      assert Accounts.get_subscription(fake_id, fake_id) == {:error, :not_found}
     end
 
     test "create_subscription/1 with valid data creates a subscription" do
@@ -111,7 +129,7 @@ defmodule KjerSi.AccountsTest do
 
     test "delete_subscription/1 deletes the subscription" do
       subscription = subscription_fixture()
-      assert {:ok, %Subscription{}} = Accounts.delete_subscription(subscription)
+      assert {:ok, %Subscription{}} = Accounts.delete_subscription(subscription.id)
       assert_raise Ecto.NoResultsError, fn -> Accounts.get_subscription!(subscription.id) end
     end
   end

--- a/backend/test/kjer_si/rooms_test.exs
+++ b/backend/test/kjer_si/rooms_test.exs
@@ -134,6 +134,16 @@ defmodule KjerSi.RoomsTest do
       assert_raise Ecto.NoResultsError, fn -> Rooms.get_room!(room.id) end
     end
 
+    test "delete_room/1 cascade-deletes related events" do
+      room = TestHelper.generate_room()
+      user = TestHelper.generate_user()
+      event = TestHelper.generate_event(user.id, room.id)
+
+      assert KjerSi.Events.list_events() == [event]
+      assert {:ok, %Room{}} = Rooms.delete_room(room)
+      assert KjerSi.Events.list_events() == []
+    end
+
     test "change_room/1 returns a room changeset" do
       room = TestHelper.generate_room()
       assert %Ecto.Changeset{} = Rooms.change_room(room)

--- a/backend/test/kjer_si_web/controllers/subscription_controller_test.exs
+++ b/backend/test/kjer_si_web/controllers/subscription_controller_test.exs
@@ -11,7 +11,7 @@ defmodule KjerSiWeb.SubscriptionControllerTest do
 
     subscription = Repo.insert!(%Subscription{user: user, room: room})
 
-    {:ok, conn: conn, user: user, subscription: subscription}
+    {:ok, conn: conn, user: user, subscription: subscription, room: room}
   end
 
   describe "index" do
@@ -72,6 +72,26 @@ defmodule KjerSiWeb.SubscriptionControllerTest do
 
       rooms_after = KjerSi.Rooms.list_rooms()
       assert length(rooms_after) == 0
+    end
+  end
+
+  describe "delete_by_room_id" do
+    test "finds subscription id and redirects to normal delete", %{
+      conn: conn,
+      subscription: subscription,
+      room: room
+    } do
+      conn = delete(conn, Routes.room_subscription_path(conn, :delete_by_room_id, room.id))
+      assert redirected_to(conn, 307) == "/api/subscriptions/#{subscription.id}"
+    end
+
+    test "fails if no subscription matches current user id and passed room_id", %{conn: conn} do
+      fake_id = "ba294533-82b6-4cbb-abc1-167cd7bf4bb1"
+
+      %{"errors" => %{"detail" => "Not Found"}} =
+        conn
+        |> delete(Routes.room_subscription_path(conn, :delete_by_room_id, fake_id))
+        |> json_response(404)
     end
   end
 end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -35,17 +35,17 @@ defmodule TestHelper do
   end
 
   def generate_event(user_id, room_id) do
-    KjerSi.Repo.insert!(
-      KjerSi.Events.Event.changeset(%KjerSi.Events.Event{}, %{
-        name: "Test event",
-        datetime: "2019-11-30 12:12:12",
-        location: "Test location",
-        description: "Just a description of the event",
-        max_attending: "2",
-        user_id: user_id,
-        room_id: room_id
-      })
-    )
+    {:ok, random_date, 0} = DateTime.from_iso8601("2019-11-30 12:12:12Z")
+
+    KjerSi.Repo.insert!(%KjerSi.Events.Event{
+      name: "Test event",
+      datetime: random_date,
+      location: "Test location",
+      description: "Just a description of the event",
+      max_attending: 2,
+      user_id: user_id,
+      room_id: room_id
+    })
   end
 
   def login_user(conn, user) do

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -34,6 +34,20 @@ defmodule TestHelper do
     )
   end
 
+  def generate_event(user_id, room_id) do
+    KjerSi.Repo.insert!(
+      KjerSi.Events.Event.changeset(%KjerSi.Events.Event{}, %{
+        name: "Test event",
+        datetime: "2019-11-30 12:12:12",
+        location: "Test location",
+        description: "Just a description of the event",
+        max_attending: "2",
+        user_id: user_id,
+        room_id: room_id
+      })
+    )
+  end
+
   def login_user(conn, user) do
     token = Phoenix.Token.sign(KjerSiWeb.Endpoint, "user auth", user.id)
     put_req_header(conn, "authorization", "Bearer #{token}")


### PR DESCRIPTION
PR doda endpoint `DELETE /api/rooms/<room_id>/subscriptions`, ki preko podanega `room_id` ter `user_id` (iz tokena) najde matching subscription in redirecta na obstoječ unsubscribe endpoint - `DELETE /api/subscriptions/<subscription_id>`.