### PR TITLE
Don't send channel history over socket after joining

### DIFF
--- a/backend/lib/kjer_si/messages/message.ex
+++ b/backend/lib/kjer_si/messages/message.ex
@@ -1,7 +1,6 @@
 defmodule KjerSi.Messages.Message do
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -18,15 +17,5 @@ defmodule KjerSi.Messages.Message do
     message
     |> cast(attrs, [:content, :room_id, :user_id])
     |> validate_required([:content, :room_id, :user_id])
-  end
-
-  def get_messages_for_room(room_id) do
-    query =
-      from m in KjerSi.Messages.Message,
-        where: m.room_id == ^room_id,
-        order_by: [asc: m.inserted_at],
-        preload: [:user]
-
-    KjerSi.Repo.all(query)
   end
 end

--- a/backend/lib/kjer_si_web/channels/chat_channel.ex
+++ b/backend/lib/kjer_si_web/channels/chat_channel.ex
@@ -52,11 +52,6 @@ defmodule KjerSiWeb.ChatChannel do
   end
 
   def handle_info(:after_join, socket) do
-    "room:" <> room_id = socket.topic
-
-    KjerSi.Messages.Message.get_messages_for_room(room_id)
-    |> Enum.each(fn msg -> push(socket, "shout", render_message(msg)) end)
-
     {:noreply, socket}
   end
 end


### PR DESCRIPTION
To se zdaj dela eksplicitno preko API endpointa (zaradi paginationa itd.), tako da funkcionalnost ni vec potrebna.